### PR TITLE
Quickfix - Presumably BuyCraft is now honoring gzip encoding header, …

### DIFF
--- a/src/buycraft/util/HTTPUtils.php
+++ b/src/buycraft/util/HTTPUtils.php
@@ -13,8 +13,7 @@ class HTTPUtils{
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
             "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:12.0) Gecko/20100101 Firefox/12.0 PocketMine-MP",
             "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            "Accept-Language: en-us",
-            "Accept-Encoding: gzip, deflate"
+            "Accept-Language: en-us"            
         ]);
         curl_setopt($ch, CURLOPT_COOKIESESSION, true );
         curl_setopt($ch, CURLOPT_COOKIEFILE, 'cookie.txt');


### PR DESCRIPTION
…however decoding is not currently implemented in the plug-in.
